### PR TITLE
Canary

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: ${{ secrets.NODE_AUTH_TOKEN }}
         
       # pulls all tags (needed for lerna / semantic release to correctly version)
       - name: Pull tags to give lerna access to git info

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.NODE_AUTH_TOKEN }}
         
       # pulls all tags (needed for lerna / semantic release to correctly version)
       - name: Pull tags to give lerna access to git info

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
         
       # pulls all tags (needed for lerna / semantic release to correctly version)
       - name: Pull tags to give lerna access to git info

--- a/packages/headline/index.js
+++ b/packages/headline/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 function Headline() {
   return (
-    <h1>Headline new new</h1>
+    <h1>Headline ff</h1>
   );
 }
 

--- a/packages/headline/package.json
+++ b/packages/headline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@JackHowa/headline",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- using jackhowa or jackhowa-personal (non setup repo) did not matter
- I added to the stable 

per @github's paul: 

Hi Jack,

Basically, protected branches and pushing to that protected branch within a github action are not possible.

This is possible using a Personal Access Token (PAT) with the correct permissions. This token should be passed to the actions/checkout@v2 step. Below is an example of how to do this:

      - uses: actions/checkout@v2
        with:        
          token: ${{ secrets.JACK_PUSH_PUBLISH_TOKEN }}

Regards,
Paul
GitHub Support